### PR TITLE
docs: fix Superpowers plugin installation instructions

### DIFF
--- a/SUPERPOWERS.md
+++ b/SUPERPOWERS.md
@@ -52,11 +52,14 @@ npx @anthropic-ai/claude-code
 
 ### Step 2: Install the Superpowers Plugin
 
-Navigate to any project directory and run:
+Start Claude Code and run these commands inside the Claude session:
 
-```bash
-claude /install-plugin superpowers-marketplace/superpowers
 ```
+/plugin marketplace add obra/superpowers-marketplace
+/plugin install superpowers@superpowers-marketplace
+```
+
+**Note:** These are slash commands that run *inside* Claude Code, not shell commands. You must start Claude first, then type these commands.
 
 The plugin installs globally and is available in all projects.
 
@@ -250,8 +253,10 @@ Remind Claude:
 
 ### Updating Superpowers
 
-```bash
-claude /update-plugin superpowers-marketplace/superpowers
+Inside a Claude Code session, run:
+
+```
+/plugin update superpowers@superpowers-marketplace
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes incorrect Superpowers plugin installation instructions in SUPERPOWERS.md.

**Previous (incorrect):**
```bash
claude /install-plugin superpowers-marketplace/superpowers
```

**Correct:**
```
/plugin marketplace add obra/superpowers-marketplace
/plugin install superpowers@superpowers-marketplace
```

**Key fixes:**
- Changed to correct `/plugin` command syntax
- Clarified these are slash commands run *inside* Claude Code, not terminal commands
- Fixed the update command in troubleshooting section

## Test plan

- [x] Verify the corrected commands match the actual Claude Code plugin syntax
- [ ] Manually test installation using the new instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated plugin installation and update instructions to use Claude Code slash commands instead of shell commands
  * Added clarification that commands should be executed within Claude Code sessions rather than a shell environment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->