### PR TITLE
fix: display shifted symbols instead of modifier+key notation

### DIFF
--- a/tests/test_svg_generator.py
+++ b/tests/test_svg_generator.py
@@ -1654,6 +1654,53 @@ class TestFallbackBranches:
         result = _format_modifier_combo("Unknown+A", "mac")
         assert result == "UnkA"  # First 3 chars + key
 
+    def test_shift_number_returns_symbol_ls_format(self):
+        """LS(4) should return $ not ⇧4."""
+        from glove80_visualizer.svg_generator import format_key_label
+
+        assert format_key_label("LS(4)") == "$"
+        assert format_key_label("LS(3)") == "#"
+        assert format_key_label("LS(5)") == "%"
+        assert format_key_label("LS(1)") == "!"
+        assert format_key_label("LS(2)") == "@"
+
+    def test_shift_number_returns_symbol_rs_format(self):
+        """RS(4) should return $ (right shift works too)."""
+        from glove80_visualizer.svg_generator import format_key_label
+
+        assert format_key_label("RS(4)") == "$"
+        assert format_key_label("RS(6)") == "^"
+
+    def test_shift_zmk_code_returns_symbol(self):
+        """LS(SEMI) should return : (colon)."""
+        from glove80_visualizer.svg_generator import format_key_label
+
+        assert format_key_label("LS(SEMI)") == ":"
+        assert format_key_label("LS(SQT)") == '"'
+        assert format_key_label("LS(COMMA)") == "<"
+
+    def test_modifier_combo_shift_number_returns_symbol(self):
+        """Sft+4 should return $ not ⇧4."""
+        from glove80_visualizer.svg_generator import _format_modifier_combo
+
+        assert _format_modifier_combo("Sft+4", "mac") == "$"
+        assert _format_modifier_combo("Shift+3", "mac") == "#"
+        assert _format_modifier_combo("Sft+5", "windows") == "%"
+
+    def test_modifier_combo_shift_zmk_code_returns_symbol(self):
+        """Sft+SEMI should return : (colon)."""
+        from glove80_visualizer.svg_generator import _format_modifier_combo
+
+        assert _format_modifier_combo("Sft+SEMI", "mac") == ":"
+        assert _format_modifier_combo("Shift+SQT", "mac") == '"'
+
+    def test_shift_with_non_shiftable_key_falls_through(self):
+        """LS(LEFT) should still show ⇧← since LEFT has no shifted variant."""
+        from glove80_visualizer.svg_generator import format_key_label
+
+        result = format_key_label("LS(LEFT)")
+        assert "⇧" in result or "←" in result  # Should have modifier + arrow
+
     def test_behavior_with_args_but_empty_abbrev(self):
         """Behavior with empty abbreviation just shows the arg."""
         from glove80_visualizer.svg_generator import format_key_label


### PR DESCRIPTION
## Summary

- Keys like `LS(4)` or `Sft+3` now display as `$` and `#` instead of `⇧4` and `⇧3`
- Makes PDF visualizations more intuitive - shows the actual character that will be typed
- Supports both ZMK notation (`LS(4)`, `RS(SEMI)`) and keymap-drawer notation (`Sft+4`, `Shift+SEMI`)

## Before/After

| Before | After |
|--------|-------|
| ⇧4 | $ |
| ⇧3 | # |
| ⇧5 | % |
| ⇧; | : |
| ⇧' | " |

## Test plan

- [x] Added 6 new tests covering all code paths
- [x] All 672 tests pass
- [x] 100% test coverage maintained
- [x] Verified PDF output shows correct symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced shifted key display to show direct symbols (e.g., $ for Shift+4) instead of modifier descriptions for clearer keyboard layouts.
  * Improved modifier combination formatting for better readability across different operating systems.
  * Expanded test coverage for key label formatting, modifier behaviors, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->